### PR TITLE
Add Asset Allocation Experiment code

### DIFF
--- a/index.html
+++ b/index.html
@@ -1627,6 +1627,10 @@
                 {
                     text: 'Glidepath',
                     value: 2
+                },
+                {
+                    text: 'Experiment',
+                    value: 3
                 }]
                 $scope.spendingPlanTypes = [{
                     text: 'Inflation Adjusted',


### PR DESCRIPTION
I **do not** intend to merge this branch, this pull request has been created so that I can document what changes I have made and the thinking behind them. I intend to keep master close to the original simulation.

This experiment was to see what happens if...  Rather than rebalancing each year, we 'rebalance' to avoid selling equities during downturns and keep a reserve of 'safe' assets the rest of the time.

So far, it appears that it does provide a very minor benefit, but this may be down to coding error or many other factors. Further investigation is still required.