### PR TITLE
Change warnings from 'integers' to 'numbers'

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@
                         </div>
                         <div class="alert alert-danger" role="alert" id="dataRateError" style="display:none">
                             <span class="sr-only">Error:</span>
-                            Market Growth must be a positive integer.
+                            Market Growth must be a positive number.
                         </div>
                         <div class="panel-body">
                             <label>
@@ -300,7 +300,7 @@
                         <div class="panel-body">
                             <div class="alert alert-danger" role="alert" id="portfolioError" style="display:none">
                                 <span class="sr-only">Error:</span>
-                                Portfolio must be a positive integer.
+                                Portfolio must be a positive number.
                             </div>
                             <label>Portfolio Value:<input type="number" class="form-control" ng-model="data.portfolio.initial"></label>
                             <div class="panel panel-default">
@@ -465,7 +465,7 @@
                         </div>
                         <div class="alert alert-danger" role="alert" id="initialSpendingError" style="display:none">
                             <span class="sr-only">Error:</span>
-                            Initial Spending amount must be a positive integer.
+                            Initial Spending amount must be a positive number.
                         </div>
                         <div class="panel-body">
                             <label>
@@ -721,7 +721,7 @@
                                     </div>
                                     <div class="alert alert-danger" role="alert" id="ssValueError" style="display:none">
                                         <span class="sr-only">Error:</span>
-                                        Amount must be a positive integer.
+                                        Amount must be a positive number.
                                     </div>
                                     <div class="row">
                                         <div class="col-md-4">
@@ -770,11 +770,11 @@
                                     </div>
                                     <div class="alert alert-danger" role="alert" id="pensionsValueError" style="display:none">
                                         <span class="sr-only">Error:</span>
-                                        Amount must be a positive integer.
+                                        Amount must be a positive number.
                                     </div>
                                     <div class="alert alert-danger" role="alert" id="pensionsRateError" style="display:none">
                                         <span class="sr-only">Error:</span>
-                                        Pension inflation rate must be a positive integer.
+                                        Pension inflation rate must be a positive number.
                                     </div>
                                     <table class="table">
                                         <thead>
@@ -846,11 +846,11 @@
                                 </div>
                                 <div class="alert alert-danger" role="alert" id="extraIncomeRateError" style="display:none">
                                     <span class="sr-only">Error:</span>
-                                    Extra Income inflation rate must be a positive integer.
+                                    Extra Income inflation rate must be a positive number.
                                 </div>
                                 <div class="alert alert-danger" role="alert" id="extraIncomeValueError" style="display:none">
                                     <span class="sr-only">Error:</span>
-                                    Amount must be a positive integer.
+                                    Amount must be a positive number.
                                 </div>
                                 <div class="alert alert-danger" role="alert" id="extraIncomeError" style="display:none">
                                     <span class="sr-only">Error:</span>
@@ -958,11 +958,11 @@
                                 </div>
                                 <div class="alert alert-danger" role="alert" id="extraSpendingValueError" style="display:none">
                                     <span class="sr-only">Error:</span>
-                                    Amount must be a positive integer.
+                                    Amount must be a positive number.
                                 </div>
                                 <div class="alert alert-danger" role="alert" id="extraSpendingRateError" style="display:none">
                                     <span class="sr-only">Error:</span>
-                                    Inflation Rate for Spending must be a positive integer.
+                                    Inflation Rate for Spending must be a positive number.
                                 </div>
                                 <div class="panel-body">
                                     <table class="table">


### PR DESCRIPTION
Many warnings talk about 'positive integers'. In fact, in most cases, it should just say 'positive number'. Decimals are allowed.