### PR TITLE
Add ability to filter historic data by starting cape

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,6 +225,10 @@
                             <span class="sr-only">Error:</span>
                             Market Growth must be a positive integer.
                         </div>
+                        <div class="alert alert-danger" role="alert" id="dataCapeError" style="display:none">
+                            <span class="sr-only">Error:</span>
+                            Starting Cape limits must be positive numbers.
+                        </div>
                         <div class="panel-body">
                             <label>
                                 Data To Use:
@@ -262,6 +266,20 @@
                                     <div class="input-group">
                                         <input type="text" class="form-control" ng-model="data.data.growth">
                                         <span class="input-group-addon">%</span>
+                                    </div>
+                                </label>
+                            </div>
+                            <div id="historicalCapeOptions" class="dataOptions" style="display:none">
+                                <label>
+                                    Minimum Starting Cape:
+                                    <div class="input-group">
+                                        <input type="text" class="form-control" ng-model="data.data.mincape">
+                                    </div>
+                                </label>
+                                <label>
+                                    Maximum Starting Cape:
+                                    <div class="input-group">
+                                        <input type="text" class="form-control" ng-model="data.data.maxcape">
                                     </div>
                                 </label>
                             </div>
@@ -1458,7 +1476,9 @@
                         start: 1900,
                         end: 1970,
                         growth: 8,
-                        singleStart: 1966
+                        singleStart: 1966,
+                        maxcape: null,
+                        mincape:null
                     },
                     investigate: {
                         type: "none",
@@ -1604,6 +1624,12 @@
                     value: 'singleCycle',
                     formInputs: [
                         'singleCycleOptions'
+                    ]
+                }, {
+                    text: 'Historical Data - Cape Filtered',
+                    value: 'historicalCape',
+                    formInputs: [
+                        'historicalCapeOptions'
                     ]
                 }]
                 $scope.investigateOptionTypes = [{
@@ -1806,18 +1832,27 @@
                         $('#historicalSpecificOptions').show();
                         $('#constantGrowthOptions').hide();
                         $('#singleCycleOptions').hide();
+                        $('#historicalCapeOptions').hide();
                     } else if ($scope.data.data.method == "constant") {
                         $('#constantGrowthOptions').show();
                         $('#historicalSpecificOptions').hide();
                         $('#singleCycleOptions').hide();
+                        $('#historicalCapeOptions').hide();
                     } else if ($scope.data.data.method == "historicalAll") {
                         $('#constantGrowthOptions').hide();
                         $('#historicalSpecificOptions').hide();
                         $('#singleCycleOptions').hide();
+                        $('#historicalCapeOptions').hide();
                     } else if ($scope.data.data.method == "singleCycle") {
                         $('#singleCycleOptions').show();
                         $('#constantGrowthOptions').hide();
                         $('#historicalSpecificOptions').hide();
+                        $('#historicalCapeOptions').hide();
+                    } else if ($scope.data.data.method == "historicalCape") {
+                        $('#historicalCapeOptions').show();
+                        $('#constantGrowthOptions').hide();
+                        $('#historicalSpecificOptions').hide();
+                        $('#singleCycleOptions').hide();
                     }
                 }
                 $scope.refreshInvestigateForm = function () {

--- a/js/cFIREsimOpen.js
+++ b/js/cFIREsimOpen.js
@@ -142,26 +142,20 @@ var Simulation = {
 		var numCycles = 0;
 		var cycleStart = 1871;
 
-		//Set number of cycles and cycleStart Year depending on Data options
-		if (form.data.method == "historicalAll" || form.data.method == "constant") {
-			numCycles = Object.keys(Market).length - cycleLength + 1;
-		} else if (form.data.method == "historicalSpecific") {
-			numCycles = (form.data.end - form.data.start) - cycleLength + 2;
-			cycleStart = parseInt(form.data.start);
-		}
 		if (form.data.method == "singleCycle") {
 			numCycles = 1;
 			cycleStart = parseInt(form.data.singleStart);
-		}
-		if (form.data.method == "singleCycle") {
 			var cyc = this.cycle(cycleStart, cycleStart + cycleLength);
 			this.sim.push(cyc);
 		} else if (form.data.method != "historicalSpecific") {
+			numCycles = Object.keys(Market).length - cycleLength + 1;
 			for (cycleStart; cycleStart < 1871 + numCycles; cycleStart++) {
 				var cyc = this.cycle(cycleStart, cycleStart + cycleLength);
 				this.sim.push(cyc);
 			}
 		} else if (form.data.method == "historicalSpecific") {
+			numCycles = (form.data.end - form.data.start) - cycleLength + 2;
+			cycleStart = parseInt(form.data.start);
 			for (var i = cycleStart; i < (cycleStart + numCycles); i++) {
 				var cyc = this.cycle(i, i + cycleLength);
 				this.sim.push(cyc);

--- a/js/cFIREsimOpen.js
+++ b/js/cFIREsimOpen.js
@@ -142,24 +142,29 @@ var Simulation = {
 		var numCycles = 0;
 		var cycleStart = 1871;
 
-		if (form.data.method == "singleCycle") {
-			numCycles = 1;
-			cycleStart = parseInt(form.data.singleStart);
-			var cyc = this.cycle(cycleStart, cycleStart + cycleLength);
-			this.sim.push(cyc);
-		} else if (form.data.method != "historicalSpecific") {
-			numCycles = Object.keys(Market).length - cycleLength + 1;
-			for (cycleStart; cycleStart < 1871 + numCycles; cycleStart++) {
+		switch (form.data.method){
+			case "singleCycle":
+				numCycles = 1;
+				cycleStart = parseInt(form.data.singleStart);
 				var cyc = this.cycle(cycleStart, cycleStart + cycleLength);
 				this.sim.push(cyc);
-			}
-		} else if (form.data.method == "historicalSpecific") {
-			numCycles = (form.data.end - form.data.start) - cycleLength + 2;
-			cycleStart = parseInt(form.data.start);
-			for (var i = cycleStart; i < (cycleStart + numCycles); i++) {
-				var cyc = this.cycle(i, i + cycleLength);
-				this.sim.push(cyc);
-			}
+				break;
+			case "historicalAll":
+			case "constant":
+				numCycles = Object.keys(Market).length - cycleLength + 1;
+				for (cycleStart; cycleStart < 1871 + numCycles; cycleStart++) {
+					var cyc = this.cycle(cycleStart, cycleStart + cycleLength);
+					this.sim.push(cyc);
+				}
+				break;
+			case "historicalSpecific":
+				numCycles = (form.data.end - form.data.start) - cycleLength + 2;
+				cycleStart = parseInt(form.data.start);
+				for (var i = cycleStart; i < (cycleStart + numCycles); i++) {
+					var cyc = this.cycle(i, i + cycleLength);
+					this.sim.push(cyc);
+				}
+				break;
 		}
 
 		if (form.investigate.type == 'none') {

--- a/js/cFIREsimOpen.js
+++ b/js/cFIREsimOpen.js
@@ -165,6 +165,21 @@ var Simulation = {
 					this.sim.push(cyc);
 				}
 				break;
+			case "historicalCape":
+				// get list of suitable start years
+				numCycles = Object.keys(Market).length - cycleLength + 1;
+				var filteredYears = [];
+				for (cycleStart; cycleStart < 1871 + numCycles; cycleStart++) {
+					if ((!form.data.mincape || form.data.mincape < Market[cycleStart]["cape"]) &&
+						(!form.data.maxcape || form.data.maxcape > Market[cycleStart]["cape"] )){
+						filteredYears.push(cycleStart)
+					}
+				}
+				for (i=0; i < filteredYears.length; i++){
+					cycleStart = filteredYears[i]
+					var cyc = this.cycle(cycleStart, cycleStart + cycleLength);
+					this.sim.push(cyc);
+				}
 		}
 
 		if (form.investigate.type == 'none') {
@@ -591,7 +606,7 @@ var Simulation = {
 		var spendingData = [];
 		var interval = results.length;
 		var cycLength = results[0].length;
-		var simLength = results.length + cycLength - 1;
+		var simLength = results[results.length-1][cycLength-1]["year"] - results[0][0]["year"] +1;
 
 		//Logic to create array for Dygraphs display. Each series must have an entry for every year in the dataset. If there is no entry for that year in the "results" array, a null value is given so that dygraphs doesn't plot there. This provides the unique look of cFIREsims graph
 		for (var i = 0; i < simLength; i++) {


### PR DESCRIPTION
Rather than looking at the full range of previous years, it would be good to filter simulations based on the initial cape, allowing you to get a realistic view of what you can expect from the current market conditions.