### PR TITLE
Update gold prices

### DIFF
--- a/js/marketData.js
+++ b/js/marketData.js
@@ -1121,7 +1121,7 @@ var Market = {
         "cpi": 226.665,
         "dividends": 0.02055749,
         "fixed_income": 0.0197,
-        "gold": 0.01262019,
+        "gold": -0.27614183,
         "growth": 0.13826139,
         "cape": 21.21
     },
@@ -1129,7 +1129,7 @@ var Market = {
         "cpi": 230.28,
         "dividends": 0.0213028,
         "fixed_income": 0.0191,
-        "gold": -0.276,
+        "gold": -0.00435866,
         "growth": 0.22114293,
         "cape": 21.9
     },
@@ -1137,7 +1137,7 @@ var Market = {
         "cpi": 233.916,
         "dividends": 0.01942536,
         "fixed_income": 0.0286,
-        "gold": -0.00004,
+        "gold": -0.11611424,
         "growth": 0.1369433,
         "cape": 24.86
     },
@@ -1145,7 +1145,7 @@ var Market = {
         "cpi": 233.707,
         "dividends": 0.019671167,
         "fixed_income": 0.0188,
-        "gold": 0,
+        "gold": 0.17994340,
         "growth": -0.054028735,
         "cape": 26.49229542
 		},
@@ -1153,7 +1153,7 @@ var Market = {
         "cpi": 236.916,
         "dividends": 0.02270058,
         "fixed_income": 0.0209,
-        "gold": 0,
+        "gold": 0.00510098,
         "growth": 0.185822996,
         "cape": 24.2061672
 		},
@@ -1161,7 +1161,7 @@ var Market = {
         "cpi": 242.839,
         "dividends": 0.020186481,
         "fixed_income": 0.0243,
-        "gold": 0,
+        "gold": 0.00904448,
         "growth": 0.226221034,
         "cape": 28.06357374
 		},
@@ -1169,7 +1169,7 @@ var Market = {
         "cpi": 247.867,
         "dividends": 0.017666738,
         "fixed_income": 0.0258,
-        "gold": 0,
+        "gold": 0.09784074,
         "growth": -0.065384615,
         "cape": 33.30734383
 		},


### PR DESCRIPTION
Gold prices were not updated since 2015 and the growth was incorrect for years starting 2012.
I used https://www.redlakemuseum.com/gold-prices.html as reference for gold prices.