### PR TITLE
Fix link to help/rebalance.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,7 +518,7 @@
                                                     ng-model="data.portfolio.rebalanceAnnually"
                                                     ng-change="refreshRebalanceAnnuallyOptions()"
                                                     ng-options="rebalanceAnnuallyOptions.value as rebalanceAnnuallyOptions.text for rebalanceAnnuallyOptions in rebalanceAnnuallyOptionsTypes"></select>
-                                                <button type="button" class="btn btn-outline-secondary btn-help" data-href="/help/rebalance.html" data-title="Annual Rebalancing Strategy">
+                                                <button type="button" class="btn btn-outline-secondary btn-help" data-href="help/rebalance.html" data-title="Annual Rebalancing Strategy">
                                                     <img src="image/help.svg"/>
                                                 </button>
                                             </div>        


### PR DESCRIPTION
The question mark button next to "Annual Rebalancing Strategy" does not show any content on the github.io hosting. This seems to be due to the link being absolute rather than relative.